### PR TITLE
bundle: use latest/stable charms from Charmhub

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+.PHONY: clean
 clean: ## Remove all deployed applications
 	juju remove-application --force percona-cluster \
 	                                slurmctld \
@@ -5,26 +6,35 @@ clean: ## Remove all deployed applications
 	                                slurmdbd \
 	                                slurmrestd
 
+.PHONY: lxd-focal
 lxd-focal: ## Deploy slurm-core in a local LXD Ubuntu Focal cluster
 	juju deploy ./slurm-core/bundle.yaml \
 	            --overlay ./slurm-core/clouds/lxd.yaml \
-	            --overlay ./slurm-core/series/focal.yaml
+	            --overlay ./slurm-core/series/focal.yaml \
+	            --overlay ./slurm-core/charms/local-development.yaml
 
+.PHONY: lxd-centos
 lxd-centos: ## Deploy slurm-core in a local LXD CentOS7 cluster
 	juju deploy ./slurm-core/bundle.yaml \
 	            --overlay ./slurm-core/clouds/lxd.yaml \
 	            --overlay ./slurm-core/series/centos7.yaml \
+	            --overlay ./slurm-core/charms/local-development.yaml
 
+.PHONY: aws-focal
 aws-focal: ## Deploy slurm-core in a AWS Ubuntu Focal cluster
 	juju deploy ./slurm-core/bundle.yaml \
 	            --overlay ./slurm-core/clouds/aws.yaml \
-	            --overlay ./slurm-core/series/focal.yaml
+	            --overlay ./slurm-core/series/focal.yaml \
+	            --overlay ./slurm-core/charms/local-development.yaml
 
+.PHONY: aws-centos
 aws-centos: ## Deploy slurm-core in a AWS CentOS7 cluster
 	juju deploy ./slurm-core/bundle.yaml \
 	            --overlay ./slurm-core/clouds/aws.yaml \
-	            --overlay ./slurm-core/series/centos7.yaml
+	            --overlay ./slurm-core/series/centos7.yaml \
+	            --overlay ./slurm-core/charms/local-development.yaml
 
+.PHONY: help
 help:
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
 
@@ -33,5 +43,5 @@ help:
 .ONESHELL:
 # Set default goal
 .DEFAULT_GOAL := help
-# Use bash shell in Make instead of sh 
+# Use bash shell in Make instead of sh
 SHELL := /bin/bash

--- a/slurm-core/bundle.yaml
+++ b/slurm-core/bundle.yaml
@@ -1,19 +1,22 @@
+name: Omnivector Slurm Distribution
+description: OSD
+
 applications:
   slurmctld:
-    charm: ./../../slurm-charms/slurmctld.charm
+    charm: slurmctld
     num_units: 1
     options:
       custom-config: |
         SlurmctldDebug=debug5
         SlurmdDebug=debug5
   slurmd:
-    charm: ./../../slurm-charms/slurmd.charm
+    charm: slurmd
     num_units: 1
   slurmdbd:
-    charm: ./../../slurm-charms/slurmdbd.charm
+    charm: slurmdbd
     num_units: 1
   slurmrestd:
-    charm: ./../../slurm-charms/slurmrestd.charm
+    charm: slurmrestd
     num_units: 1
   percona-cluster:
     charm: cs:percona-cluster-293

--- a/slurm-core/charms/latest-edge.yaml
+++ b/slurm-core/charms/latest-edge.yaml
@@ -1,0 +1,9 @@
+applications:
+  slurmctld:
+    channel: latest/edge
+  slurmd:
+    channel: latest/edge
+  slurmdbd:
+    channel: latest/edge
+  slurmrestd:
+    channel: latest/edge

--- a/slurm-core/charms/local-development.yaml
+++ b/slurm-core/charms/local-development.yaml
@@ -1,0 +1,9 @@
+applications:
+  slurmctld:
+    charm: ./../../../slurm-charms/slurmctld.charm
+  slurmd:
+    charm: ./../../../slurm-charms/slurmd.charm
+  slurmdbd:
+    charm: ./../../../slurm-charms/slurmdbd.charm
+  slurmrestd:
+    charm: ./../../../slurm-charms/slurmrestd.charm


### PR DESCRIPTION
By default, we use the latest/stable slurm-charms from Charmhub. If the
user wants another channel, they can use the charms/latest-edge.yaml
overlay for the latest/edge charms. Additionally, the overlay
charms/local-development.yaml provides the charms from disk.

The Makefile should use the local-development overlay by default, as it
is merely a convenience tool for local testing and development.