### PR TITLE
addons: add monitoring overlay

### DIFF
--- a/slurm-addons/influxdb.yaml
+++ b/slurm-addons/influxdb.yaml
@@ -4,5 +4,4 @@ applications:
     num_units: 1
     series: focal
 relations:
-  - - influxdb:query
-    - slurmctld:influxdb-api
+  - [influxdb:query, slurmctld:influxdb-api]

--- a/slurm-addons/monitoring.yaml
+++ b/slurm-addons/monitoring.yaml
@@ -1,0 +1,21 @@
+applications:
+  prometheus2:
+    charm: prometheus2
+    num_units: 1
+    series: focal
+  node-exporter:
+    charm: prometheus-node-exporter
+    series: focal
+relations:
+  - - prometheus2:scrape
+    - node-exporter:prometheus
+  - - node-exporter:juju-info
+    - slurmd:juju-info
+  - - node-exporter:juju-info
+    - slurmctld:juju-info
+  - - node-exporter:juju-info
+    - slurmdbd:juju-info
+  - - node-exporter:juju-info
+    - slurmrestd:juju-info
+  - - node-exporter:juju-info
+    - percona-cluster:juju-info

--- a/slurm-addons/monitoring.yaml
+++ b/slurm-addons/monitoring.yaml
@@ -7,15 +7,9 @@ applications:
     charm: prometheus-node-exporter
     series: focal
 relations:
-  - - prometheus2:scrape
-    - node-exporter:prometheus
-  - - node-exporter:juju-info
-    - slurmd:juju-info
-  - - node-exporter:juju-info
-    - slurmctld:juju-info
-  - - node-exporter:juju-info
-    - slurmdbd:juju-info
-  - - node-exporter:juju-info
-    - slurmrestd:juju-info
-  - - node-exporter:juju-info
-    - percona-cluster:juju-info
+  - [prometheus2:scrape, node-exporter:prometheus]
+  - [node-exporter:juju-info, slurmd:juju-info]
+  - [node-exporter:juju-info, slurmctld:juju-info]
+  - [node-exporter:juju-info, slurmdbd:juju-info]
+  - [node-exporter:juju-info, slurmrestd:juju-info]
+  - [node-exporter:juju-info, percona-cluster:juju-info]

--- a/slurm-core/bundle.yaml
+++ b/slurm-core/bundle.yaml
@@ -23,11 +23,7 @@ applications:
     series: bionic
     num_units: 1
 relations:
-  - - slurmdbd:db
-    - percona-cluster:db
-  - - slurmctld:slurmdbd
-    - slurmdbd:slurmdbd
-  - - slurmctld:slurmd
-    - slurmd:slurmd
-  - - slurmctld:slurmrestd
-    - slurmrestd:slurmrestd
+  - [slurmdbd:db, percona-cluster:db]
+  - [slurmctld:slurmdbd, slurmdbd:slurmdbd]
+  - [slurmctld:slurmd, slurmd:slurmd]
+  - [slurmctld:slurmrestd, slurmrestd:slurmrestd]


### PR DESCRIPTION
This overlay deploys a Prometheus2 instance and prometheus-node-exporter
to all nodes in the cluster.