### PR TITLE
Add singularity .deb and .rpm resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,29 +11,33 @@ clean: ## Remove all deployed applications
 ${ETCD}: ## Download etcd resource
 	wget https://github.com/etcd-io/etcd/releases/download/v3.5.0/${ETCD}
 
+singularity: ## Donwload singularity .deb and .rpm
+	wget https://github.com/sylabs/singularity/releases/download/v3.10.2/singularity-ce_3.10.2-focal_amd64.deb
+	wget https://github.com/sylabs/singularity/releases/download/v3.10.2/singularity-ce-3.10.2-1.el7.x86_64.rpm
+
 .PHONY: lxd-focal
-lxd-focal: ${ETCD} ## Deploy slurm-core in a local LXD Ubuntu Focal cluster
+lxd-focal: ${ETCD} singularity ## Deploy slurm-core in a local LXD Ubuntu Focal cluster
 	juju deploy ./slurm-core/bundle.yaml \
 	            --overlay ./slurm-core/clouds/lxd.yaml \
 	            --overlay ./slurm-core/series/focal.yaml \
 	            --overlay ./slurm-core/charms/local-development.yaml
 
 .PHONY: lxd-centos
-lxd-centos: ${ETCD} ## Deploy slurm-core in a local LXD CentOS7 cluster
+lxd-centos: ${ETCD} singularity ## Deploy slurm-core in a local LXD CentOS7 cluster
 	juju deploy ./slurm-core/bundle.yaml \
 	            --overlay ./slurm-core/clouds/lxd.yaml \
 	            --overlay ./slurm-core/series/centos7.yaml \
 	            --overlay ./slurm-core/charms/local-development.yaml
 
 .PHONY: aws-focal
-aws-focal: ${ETCD} ## Deploy slurm-core in a AWS Ubuntu Focal cluster
+aws-focal: ${ETCD} singularity ## Deploy slurm-core in a AWS Ubuntu Focal cluster
 	juju deploy ./slurm-core/bundle.yaml \
 	            --overlay ./slurm-core/clouds/aws.yaml \
 	            --overlay ./slurm-core/series/focal.yaml \
 	            --overlay ./slurm-core/charms/local-development.yaml
 
 .PHONY: aws-centos
-aws-centos: ${ETCD} ## Deploy slurm-core in a AWS CentOS7 cluster
+aws-centos: ${ETCD} singularity ## Deploy slurm-core in a AWS CentOS7 cluster
 	juju deploy ./slurm-core/bundle.yaml \
 	            --overlay ./slurm-core/clouds/aws.yaml \
 	            --overlay ./slurm-core/series/centos7.yaml \

--- a/slurm-core/charms/local-development.yaml
+++ b/slurm-core/charms/local-development.yaml
@@ -9,6 +9,9 @@ applications:
       etcd: ./../etcd-v3.5.0-linux-amd64.tar.gz
   slurmd:
     charm: ./../../../slurm-charms/slurmd.charm
+    resources:
+      singularity-deb: ./../singularity-ce_3.10.2-focal_amd64.deb
+      singularity-rpm: ./../singularity-ce-3.10.2-1.el7.x86_64.rpm
   slurmdbd:
     charm: ./../../../slurm-charms/slurmdbd.charm
   slurmrestd:


### PR DESCRIPTION
This new feature downloads singularity .deb and .rpm files from github and adds the respective resources.

This is necessary for  https://github.com/jaimesouza/slurm-charms/tree/jaime-dev-singularity

**How was the code tested?**

The code was tested locally.


Final checklist
- [ x ] I am the author of these changes, or I have the rights to submit them.
- [ ] I added the relevant changed to the README and/or documentation.
- [ x ] I self reviewed my own code.
- [ ] I updated the `CHANGELOG` according to the [contributing
  guide](https://omnivector-solutions.github.io/osd-documentation/master/contributing.html#changelog)
