### PR TITLE
Remove NHC resource from local-development.yaml

### DIFF
--- a/slurm-core/charms/local-development.yaml
+++ b/slurm-core/charms/local-development.yaml
@@ -9,8 +9,6 @@ applications:
       etcd: ./../etcd-v3.5.0-linux-amd64.tar.gz
   slurmd:
     charm: ./../../../slurm-charms/slurmd.charm
-    resources:      
-      nhc: ./../lbnl-nhc-1.4.3.tar.gz
   slurmdbd:
     charm: ./../../../slurm-charms/slurmdbd.charm
   slurmrestd:


### PR DESCRIPTION
**What**

Remove NHC resource from local-development.yaml

**Why**

The NHC resource has been removed from slurmd charm.
