### PR TITLE
Replace percona-cluster by mysql charm

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,8 @@
 ETCD=etcd-v3.5.0-linux-amd64.tar.gz
-NHC=lbnl-nhc-1.4.3.tar.gz
 
 .PHONY: clean
 clean: ## Remove all deployed applications
-	juju remove-application --force percona-cluster \
+	juju remove-application --force mysql \
 	                                slurmctld \
 	                                slurmd \
 	                                slurmdbd \
@@ -12,16 +11,13 @@ clean: ## Remove all deployed applications
 ${ETCD}: ## Download etcd resource
 	wget https://github.com/etcd-io/etcd/releases/download/v3.5.0/${ETCD}
 
-${NHC}: ## Download NHC resource
-	wget https://github.com/mej/nhc/releases/download/1.4.3/${NHC}
+resources: ${ETCD} ## Download all resources
 
-resources: ${ETCD} ${NHC} ## Download all resources
-
-.PHONY: lxd-focal
-lxd-focal: resources ## Deploy slurm-core in a local LXD Ubuntu Focal cluster
+.PHONY: lxd-jammy
+lxd-jammy: resources ## Deploy slurm-core in a local LXD Ubuntu Jammy cluster
 	juju deploy ./slurm-core/bundle.yaml \
 	            --overlay ./slurm-core/clouds/lxd.yaml \
-	            --overlay ./slurm-core/series/focal.yaml \
+	            --overlay ./slurm-core/series/jammy.yaml \
 	            --overlay ./slurm-core/charms/local-development.yaml
 
 .PHONY: lxd-centos
@@ -31,11 +27,11 @@ lxd-centos: resources ## Deploy slurm-core in a local LXD CentOS7 cluster
 	            --overlay ./slurm-core/series/centos7.yaml \
 	            --overlay ./slurm-core/charms/local-development.yaml
 
-.PHONY: aws-focal
-aws-focal: resources ## Deploy slurm-core in a AWS Ubuntu Focal cluster
+.PHONY: aws-jammy
+aws-jammy: resources ## Deploy slurm-core in a AWS Ubuntu Jammy cluster
 	juju deploy ./slurm-core/bundle.yaml \
 	            --overlay ./slurm-core/clouds/aws.yaml \
-	            --overlay ./slurm-core/series/focal.yaml \
+	            --overlay ./slurm-core/series/jammy.yaml \
 	            --overlay ./slurm-core/charms/local-development.yaml
 
 .PHONY: aws-centos

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ following components:
 - `slurmdbd` node: the database accounting node
 - `slurmd` node: the compute node
 - `slurmrestd` node: the REST API interface to Slurm
-- `percona-cluster` node: the MySQL database
+- `mysql` node: the MySQL database
 
 ## Documentation
 

--- a/slurm-core/bundle.yaml
+++ b/slurm-core/bundle.yaml
@@ -29,7 +29,11 @@ applications:
       mysql-interface-user: slurmdbd
 
 relations:
-  - [mysql:mysql, slurmdbd:db]
-  - [slurmctld:slurmdbd, slurmdbd:slurmdbd]
-  - [slurmctld:slurmd, slurmd:slurmd]
-  - [slurmctld:slurmrestd, slurmrestd:slurmrestd]
+- - mysql:mysql
+  - slurmdbd:db
+- - slurmctld:slurmdbd
+  - slurmdbd:slurmdbd
+- - slurmctld:slurmd
+  - slurmd:slurmd
+- - slurmctld:slurmrestd
+  - slurmrestd:slurmrestd

--- a/slurm-core/bundle.yaml
+++ b/slurm-core/bundle.yaml
@@ -5,7 +5,7 @@ docs: https://omnivector-solutions.github.io/osd-documentation/master/
 source: https://github.com/omnivector-solutions/slurm-bundles/
 issues: https://github.com/omnivector-solutions/slurm-charms/issues
 
-series: focal
+series: jammy
 
 applications:
   slurmctld:
@@ -20,12 +20,16 @@ applications:
   slurmrestd:
     charm: slurmrestd
     num_units: 1
-  percona-cluster:
-    charm: cs:percona-cluster-293
-    series: bionic
+  mysql:
+    charm: mysql
+    series: jammy
     num_units: 1
+    options:
+      mysql-interface-database: slurmdbd
+      mysql-interface-user: slurmdbd
+
 relations:
-  - [slurmdbd:db, percona-cluster:db]
+  - [mysql:mysql, slurmdbd:db]
   - [slurmctld:slurmdbd, slurmdbd:slurmdbd]
   - [slurmctld:slurmd, slurmd:slurmd]
   - [slurmctld:slurmrestd, slurmrestd:slurmrestd]

--- a/slurm-core/clouds/aws.yaml
+++ b/slurm-core/clouds/aws.yaml
@@ -1,16 +1,14 @@
 applications:
-  percona-cluster:
+  mysql:
     constraints: instance-type=t3a.small spaces=nat
     bindings:
       "": nat
-      access: nat
-      cluster: nat
-      db: nat
-      db-admin: nat
-      ha: nat
-      master: nat
+      cos-agent: nat
+      db-router: nat
+      mysql: nat
       shared-db: nat
-      slave: nat
+      certificates: nat
+      s3-parameters: nat
   slurmctld:
     constraints: instance-type=t3a.small spaces=nat
     bindings:

--- a/slurm-core/series/focal.yaml
+++ b/slurm-core/series/focal.yaml
@@ -1,1 +1,0 @@
-series: focal

--- a/slurm-core/series/jammy.yaml
+++ b/slurm-core/series/jammy.yaml
@@ -1,0 +1,1 @@
+series: jammy


### PR DESCRIPTION
**What**

- Update the bundles, replacing `percona-cluster` by `MySQL` charm.
- Add support for Ubuntu Jammy.

**Why**

Percona-cluster is not supported by Juju 3.x.